### PR TITLE
Add wktLiteral @type for geojson:geometry

### DIFF
--- a/contexts/geojson-base.jsonld
+++ b/contexts/geojson-base.jsonld
@@ -20,7 +20,10 @@
       "@container": "@set",
       "@id": "geojson:features"
     },
-    "geometry": "geojson:geometry",
+    "geometry": {
+      "@id": "geojson:geometry",
+      "@type": "http://www.opengis.net/ont/geosparql:wktLiteral"
+    },
     "id": "@id",
     "properties": "geojson:properties",
     "title": "http://purl.org/dc/terms/title",

--- a/contexts/geojson-time.jsonld
+++ b/contexts/geojson-time.jsonld
@@ -27,7 +27,11 @@
       "@container": "@set",
       "@id": "geojson:features"
     },
-    "geometry": "geojson:geometry",
+    "geometry": {
+      "@container": "x-geojson-geometry-container",
+      "@id": "geojson:geometry",
+      "@type": "http://www.opengis.net/ont/geosparql:wktLiteral"
+    },
     "id": "@id",
     "properties": "geojson:properties",
     "start": {


### PR DESCRIPTION
Towards closing https://github.com/geojson/geojson-ld/issues/32.

This helps RDF users get usable RDF by coercion of GeoJSON geometry to WKT.

It does nothing for RDF -> GeoJSON, but I don't think this lack has to be a blocker for a first release of GeoJSON-LD on the web.

Definition of a new container types specific to GeoJSON geometry objects and N-D arrays could assist with RDF -> GeoJSON conversions as well as serialization of geometries to pure RDF, but let's defer work on those.

Reviews welcome!