### PR TITLE
Remove JSON-LD from time.md

### DIFF
--- a/time.md
+++ b/time.md
@@ -1,4 +1,4 @@
-# Event-like GeoJSON Features Using JSON-LD
+# Event-like GeoJSON Features
 
 With the addition of temporal items, GeoJSON features can become event-like and
 such features will be used in the following examples.
@@ -10,19 +10,11 @@ GeoJSON processors.
 ## Proposal in a nutshell
 
 - A "when" object analogous to GeoJSON's existing "geometry".
-- Two "@types" of temporality: "Instant" and "Interval".
+- Two types of temporality: "Instant" and "Interval".
 - The values of items in "when" are ISO-8601 or RFC 3339 date/time strings.
 - The keys of those items are "datetime", "start", "stop".
 - The keys "earliest" and "latest" are being considered as a way to communicate
   fuzziness or imprecision.
-
-Please note that *example.com/vocab* is used as a placeholder for a namespace
-yet to be published.
-
-## JSON-LD Playground
-
-Copy any of the JSON text below and paste at http://json-ld.org/playground/ to
-see it processed.
 
 ## Instantaneous event-like feature
 
@@ -30,49 +22,6 @@ For a thing that exists at a certain time.
 
 ```
 {
-  "@context": {
-    "geojson": "http://ld.geojson.org/vocab#",
-    "Feature": "geojson:Feature",
-    "FeatureCollection": "geojson:FeatureCollection",
-    "GeometryCollection": "geojson:GeometryCollection",
-    "Instant": "http://www.w3.org/2006/time#Instant",
-    "Interval": "http://www.w3.org/2006/time#Interval",
-    "LineString": "geojson:LineString",
-    "MultiLineString": "geojson:MultiLineString",
-    "MultiPoint": "geojson:MultiPoint",
-    "MultiPolygon": "geojson:MultiPolygon",
-    "Point": "geojson:Point",
-    "Polygon": "geojson:Polygon",
-    "bbox": {
-      "@container": "@list",
-      "@id": "geojson:bbox"
-    },
-    "circa": "geojson:circa",
-    "coordinates": "geojson:coordinates",
-    "datetime": {
-      "@id": "geojson:datetime",
-      "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
-    },
-    "description": "http://purl.org/dc/terms/description",
-    "features": {
-      "@container": "@set",
-      "@id": "geojson:features"
-    },
-    "geometry": "geojson:geometry",
-    "id": "@id",
-    "properties": "geojson:properties",
-    "start": {
-      "@id": "geojson:start",
-      "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
-    },
-    "stop": {
-      "@id": "geojson:stop",
-      "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
-    },
-    "title": "http://purl.org/dc/terms/title",
-    "type": "@type",
-    "when": "geojson:when"
-  },
   "geometry": {
     "coordinates": [
       0.0,
@@ -83,10 +32,9 @@ For a thing that exists at a certain time.
   "id": "1",
   "properties": {},
   "type": "Feature",
-  "@type": "Feature",
   "when": {
     "datetime": "2014-04-24",
-    "@type": "Instant"
+    "type": "Instant"
   }
 }
 ```
@@ -97,49 +45,6 @@ For a thing that exists during a certain interval.
 
 ```
 {
-  "@context": {
-    "geojson": "http://ld.geojson.org/vocab#",
-    "Feature": "geojson:Feature",
-    "FeatureCollection": "geojson:FeatureCollection",
-    "GeometryCollection": "geojson:GeometryCollection",
-    "Instant": "http://www.w3.org/2006/time#Instant",
-    "Interval": "http://www.w3.org/2006/time#Interval",
-    "LineString": "geojson:LineString",
-    "MultiLineString": "geojson:MultiLineString",
-    "MultiPoint": "geojson:MultiPoint",
-    "MultiPolygon": "geojson:MultiPolygon",
-    "Point": "geojson:Point",
-    "Polygon": "geojson:Polygon",
-    "bbox": {
-      "@container": "@list",
-      "@id": "geojson:bbox"
-    },
-    "circa": "geojson:circa",
-    "coordinates": "geojson:coordinates",
-    "datetime": {
-      "@id": "geojson:datetime",
-      "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
-    },
-    "description": "http://purl.org/dc/terms/description",
-    "features": {
-      "@container": "@set",
-      "@id": "geojson:features"
-    },
-    "geometry": "geojson:geometry",
-    "id": "@id",
-    "properties": "geojson:properties",
-    "start": {
-      "@id": "geojson:start",
-      "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
-    },
-    "stop": {
-      "@id": "geojson:stop",
-      "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
-    },
-    "title": "http://purl.org/dc/terms/title",
-    "type": "@type",
-    "when": "geojson:when"
-  },
   "geometry": {
     "coordinates": [
       0.0,
@@ -150,11 +55,10 @@ For a thing that exists during a certain interval.
   "id": "1",
   "properties": {},
   "type": "Feature",
-  "@type": "Feature",
   "when": {
     "start": "2014-04-24",
     "stop": "2014-04-25",
-    "@type": "Interval"
+    "type": "Interval"
   }
 }
 ```
@@ -165,49 +69,6 @@ For a thing that exists *since* a certain time.
 
 ```
 {
-  "@context": {
-    "geojson": "http://ld.geojson.org/vocab#",
-    "Feature": "geojson:Feature",
-    "FeatureCollection": "geojson:FeatureCollection",
-    "GeometryCollection": "geojson:GeometryCollection",
-    "Instant": "http://www.w3.org/2006/time#Instant",
-    "Interval": "http://www.w3.org/2006/time#Interval",
-    "LineString": "geojson:LineString",
-    "MultiLineString": "geojson:MultiLineString",
-    "MultiPoint": "geojson:MultiPoint",
-    "MultiPolygon": "geojson:MultiPolygon",
-    "Point": "geojson:Point",
-    "Polygon": "geojson:Polygon",
-    "bbox": {
-      "@container": "@list",
-      "@id": "geojson:bbox"
-    },
-    "circa": "geojson:circa",
-    "coordinates": "geojson:coordinates",
-    "datetime": {
-      "@id": "geojson:datetime",
-      "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
-    },
-    "description": "http://purl.org/dc/terms/description",
-    "features": {
-      "@container": "@set",
-      "@id": "geojson:features"
-    },
-    "geometry": "geojson:geometry",
-    "id": "@id",
-    "properties": "geojson:properties",
-    "start": {
-      "@id": "geojson:start",
-      "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
-    },
-    "stop": {
-      "@id": "geojson:stop",
-      "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
-    },
-    "title": "http://purl.org/dc/terms/title",
-    "type": "@type",
-    "when": "geojson:when"
-  },
   "geometry": {
     "coordinates": [
       0.0,
@@ -218,10 +79,9 @@ For a thing that exists *since* a certain time.
   "id": "1",
   "properties": {},
   "type": "Feature",
-  "@type": "Feature",
   "when": {
     "start": "2014-04-24",
-    "@type": "Interval"
+    "type": "Interval"
   }
 }
 ```
@@ -233,49 +93,6 @@ things is a feature of Simile's Timeline.
 
 ```
 {
-  "@context": {
-    "geojson": "http://ld.geojson.org/vocab#",
-    "Feature": "geojson:Feature",
-    "FeatureCollection": "geojson:FeatureCollection",
-    "GeometryCollection": "geojson:GeometryCollection",
-    "Instant": "http://www.w3.org/2006/time#Instant",
-    "Interval": "http://www.w3.org/2006/time#Interval",
-    "LineString": "geojson:LineString",
-    "MultiLineString": "geojson:MultiLineString",
-    "MultiPoint": "geojson:MultiPoint",
-    "MultiPolygon": "geojson:MultiPolygon",
-    "Point": "geojson:Point",
-    "Polygon": "geojson:Polygon",
-    "bbox": {
-      "@container": "@list",
-      "@id": "geojson:bbox"
-    },
-    "circa": "geojson:circa",
-    "coordinates": "geojson:coordinates",
-    "datetime": {
-      "@id": "geojson:datetime",
-      "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
-    },
-    "description": "http://purl.org/dc/terms/description",
-    "features": {
-      "@container": "@set",
-      "@id": "geojson:features"
-    },
-    "geometry": "geojson:geometry",
-    "id": "@id",
-    "properties": "geojson:properties",
-    "start": {
-      "@id": "geojson:start",
-      "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
-    },
-    "stop": {
-      "@id": "geojson:stop",
-      "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
-    },
-    "title": "http://purl.org/dc/terms/title",
-    "type": "@type",
-    "when": "geojson:when"
-  },
   "geometry": {
     "coordinates": [
       0.0,
@@ -286,15 +103,14 @@ things is a feature of Simile's Timeline.
   "id": "1",
   "properties": {},
   "type": "Feature",
-  "@type": "Feature",
   "circa": {
     "start": "2014-04-23",
     "stop": "2014-04-25",
-    "@type": "Interval"
+    "type": "Interval"
   },
   "when": {
     "datetime": "2014-04-24",
-    "@type": "Instant"
+    "type": "Instant"
   }
 }
 ```
@@ -305,49 +121,6 @@ For a thing that exists since an approximately known time.
 
 ```
 {
-  "@context": {
-    "geojson": "http://ld.geojson.org/vocab#",
-    "Feature": "geojson:Feature",
-    "FeatureCollection": "geojson:FeatureCollection",
-    "GeometryCollection": "geojson:GeometryCollection",
-    "Instant": "http://www.w3.org/2006/time#Instant",
-    "Interval": "http://www.w3.org/2006/time#Interval",
-    "LineString": "geojson:LineString",
-    "MultiLineString": "geojson:MultiLineString",
-    "MultiPoint": "geojson:MultiPoint",
-    "MultiPolygon": "geojson:MultiPolygon",
-    "Point": "geojson:Point",
-    "Polygon": "geojson:Polygon",
-    "bbox": {
-      "@container": "@list",
-      "@id": "geojson:bbox"
-    },
-    "circa": "geojson:circa",
-    "coordinates": "geojson:coordinates",
-    "datetime": {
-      "@id": "geojson:datetime",
-      "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
-    },
-    "description": "http://purl.org/dc/terms/description",
-    "features": {
-      "@container": "@set",
-      "@id": "geojson:features"
-    },
-    "geometry": "geojson:geometry",
-    "id": "@id",
-    "properties": "geojson:properties",
-    "start": {
-      "@id": "geojson:start",
-      "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
-    },
-    "stop": {
-      "@id": "geojson:stop",
-      "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
-    },
-    "title": "http://purl.org/dc/terms/title",
-    "type": "@type",
-    "when": "geojson:when"
-  },
   "geometry": {
     "coordinates": [
       0.0,
@@ -358,15 +131,13 @@ For a thing that exists since an approximately known time.
   "id": "1",
   "properties": {},
   "type": "Feature",
-  "@type": "Feature",
   "circa": {
     "start": "2014-04-23",
-    "@type": "Interval"
+    "type": "Interval"
   },
   "when": {
     "start": "2014-04-24",
-    "@type": "Interval"
+    "type": "Interval"
   }
 }
 ```
-


### PR DESCRIPTION
GeoJSON-LD is currently blocked where the multidimensional coordinates array runs up against lack of support in RDF and JSON-LD for N-D arrays. To unblock the temporal extension, let's remove JSON-LD from it and move on using `type` in the not-LD sense.