### PR TITLE
Update for Linked Data 1.1

### DIFF
--- a/geojson-context.jsonld
+++ b/geojson-context.jsonld
@@ -1,5 +1,6 @@
 {
   "@context": {
+    "@version": 1.1,
     "geojson": "https://purl.org/geojson/vocab#",
     "Feature": "geojson:Feature",
     "FeatureCollection": "geojson:FeatureCollection",

--- a/index.md
+++ b/index.md
@@ -7,9 +7,9 @@ title: GeoJSON-LD
 
 **Author**: Sean Gillies (Mapbox)
 
-**Revision**: 1.0
+**Revision**: 1.1
 
-**Date**: 2017-01-03
+**Date**: 2021-12-20
 
 **Abstract**: A vocabulary and JSON-LD context for GeoJSON.
 
@@ -50,6 +50,7 @@ Pasting the following GeoJSON-LD document
 ```json
 {
   "@context": {
+    "@version": 1.1,
     "geojson": "https://purl.org/geojson/vocab#",
     "Feature": "geojson:Feature",
     "FeatureCollection": "geojson:FeatureCollection",
@@ -135,6 +136,9 @@ the following JSON-LD in expanded form.
   }
 ]
 ```
+
+## Note
+JSON-LD 1.0 [cannot process the "list of list" structure](https://www.w3.org/TR/2014/REC-json-ld-20140116/#dfn-list-object), so many GeoJSON shapes cannot be processed by JSON-LD 1.0 validators. The `"@version": 1.1` property has been added to the GeoJSON-LD context to tell JSON-LD processors to process GeoJSON under the Linked Data 1.1 schema, which [can process the "list of list" structure](https://www.w3.org/TR/json-ld11/#dfn-list-object).  
 
 ## See Also
 

--- a/index.md
+++ b/index.md
@@ -138,7 +138,7 @@ the following JSON-LD in expanded form.
 ```
 
 ## Note
-JSON-LD 1.0 [cannot process the "list of list" structure](https://www.w3.org/TR/2014/REC-json-ld-20140116/#dfn-list-object), so many GeoJSON shapes cannot be processed by JSON-LD 1.0 validators. The `"@version": 1.1` property has been added to the GeoJSON-LD context to tell JSON-LD processors to process GeoJSON under the Linked Data 1.1 schema, which [can process the "list of list" structure](https://www.w3.org/TR/json-ld11/#dfn-list-object).  
+JSON-LD 1.0 [cannot process the "list of list" structure](https://www.w3.org/TR/2014/REC-json-ld-20140116/#h_note_8), so many GeoJSON shapes cannot be processed by JSON-LD 1.0 validators. The `"@version": 1.1` property has been added to the GeoJSON-LD context to tell JSON-LD processors to process GeoJSON under the Linked Data 1.1 schema, which [can process the "list of list" structure](https://www.w3.org/TR/json-ld11/#example-82-specifying-that-a-collection-is-ordered-in-the-context).  
 
 ## See Also
 

--- a/index.md
+++ b/index.md
@@ -138,7 +138,7 @@ the following JSON-LD in expanded form.
 ```
 
 ## Note
-JSON-LD 1.0 [cannot process the "list of list" structure](https://www.w3.org/TR/2014/REC-json-ld-20140116/#h_note_8), so many GeoJSON shapes cannot be processed by JSON-LD 1.0 validators. The `"@version": 1.1` property has been added to the GeoJSON-LD context to tell JSON-LD processors to process GeoJSON under the Linked Data 1.1 schema, which [can process the "list of list" structure](https://www.w3.org/TR/json-ld11/#example-82-specifying-that-a-collection-is-ordered-in-the-context).  
+JSON-LD 1.0 [cannot process the "list of list" structure](https://www.w3.org/TR/2014/REC-json-ld-20140116/#h_note_8), so many GeoJSON shapes cannot be processed by JSON-LD 1.0 validators. The `"@version": 1.1` property has been added to the GeoJSON-LD context to tell JSON-LD processors to process GeoJSON under the Linked Data 1.1 format, which [can process the "list of list" structure](https://www.w3.org/TR/json-ld11/#example-82-specifying-that-a-collection-is-ordered-in-the-context).  
 
 ## See Also
 


### PR DESCRIPTION
Minimum requirements to update GeoJSON-LD for Linked Data 1.1 processors.  Now all shapes can be validated by JSON-LD processors, and it is important to note that most shapes are not JSON-LD 1.0 compatible.  See https://www.w3.org/TR/2014/REC-json-ld-20140116/#h_note_8.  This PR will add `"@version": 1.1` to the context file and the example, as well as add the note about JSON-LD 1.0 vs JSON-LD 1.1 with relevant links.

A further update could be to replace the example for one with a simple `LineString` or `Polygon`, so as to be showing an example where the shape is a "list of list" (Array, where an index in the Array is an Array).  This is not necessary though.

